### PR TITLE
CASMHMS-5622: Update RTS to newer image that does not have hardcoded HTTPs certificate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 .idea
 pcsbinary
+
+# Prevent certificates from getting checked in
+*.ca
+*.cer
+*.crt
+*.csr
+*.key
+*.pem

--- a/Dockerfile.integration.Dockerfile
+++ b/Dockerfile.integration.Dockerfile
@@ -59,7 +59,6 @@ RUN set -ex \
 # Get the hms-power-control from the builder stage.
 COPY --from=builder /usr/local/bin/hms-power-control /usr/local/bin/.
 COPY configs configs
-COPY ephemeral_cert configs
 COPY .version /
 
 

--- a/Dockerfile.unittesting.Dockerfile
+++ b/Dockerfile.unittesting.Dockerfile
@@ -54,7 +54,6 @@ RUN go env -w GO111MODULE=auto
 COPY cmd $GOPATH/src/github.com/Cray-HPE/hms-power-control/cmd
 COPY configs configs
 COPY scripts scripts
-COPY ephemeral_cert configs
 COPY vendor $GOPATH/src/github.com/Cray-HPE/hms-power-control/vendor
 COPY internal $GOPATH/src/github.com/Cray-HPE/hms-power-control/internal
 COPY .version $GOPATH/src/github.com/Cray-HPE/hms-power-control/.version

--- a/docker-compose.developer.environment.yaml
+++ b/docker-compose.developer.environment.yaml
@@ -39,13 +39,6 @@ services:
       - vault
     networks:
       - pcs
-  redis:
-    image: artifactory.algol60.net/docker.io/library/redis:5.0-alpine3.12
-    hostname: hms-redfish-redis
-    ports:
-      - "6379:6379"
-    networks:
-      - pcs
   hmsds-postgres:
     hostname: hmsds-postgres
     image: artifactory.algol60.net/docker.io/library/postgres:11-alpine
@@ -134,40 +127,5 @@ services:
       - ./configs/token:/configs/token
     networks:
       - pcs
-  redfish-simulator:
-    image: artifactory.algol60.net/csm-docker/stable/hms-redfish-translation-service:1.13.3
-    environment:
-      - SCHEMA_VERSION=2019.1
-      - LOG_LEVEL=TRACE
-      - PRIVILEGE_REGISTRY_VERSION=1.0.4
-      - SCRIPT_DIR_PREFIX=/tmp/redfish
-      - VAULT_TOKEN=hms
-      - REDIS_HOSTNAME=redis
-      - REDIS_PORT=6379
-      - VAULT_ADDR=http://vault:8200
-      - CRAY_VAULT_JWT_FILE=configs/token
-      - CRAY_VAULT_ROLE_FILE=configs/namespace
-      - CRAY_VAULT_AUTH_PATH=auth/token/create
-      - HTTPS_CERT=configs/rts.crt
-      - HTTPS_KEY=configs/rts.key
-      - BACKEND_HELPER=RFSimulator
-      - PERIODIC_SLEEP=120
-      - COLLECTOR_URL=http://cray-hms-hmcollector
-      - HSM_URL=http://cray-smd:27779
-      - HMS_VAULT_KEYPATH=hms-creds
-      - RF_USERNAME=root
-      - RF_PASSWORD=testpassword
-      - RF_SIMULATOR_XNAMES=x0c0s1b0,x0c0s2b0
-      - LOGLEVEL=4
-    ports:
-      - "8082:8082"
-      - "8083:8083"
-    depends_on:
-      - redis
-      - vault
-      - cray-smd
-    networks:
-      pcs:
-        aliases:
-          - x0c0s1b0
-          - x0c0s2b0
+
+# TODO replace simulated BMC with RIE

--- a/docker-compose.developer.full.yaml
+++ b/docker-compose.developer.full.yaml
@@ -63,13 +63,6 @@ services:
       - vault
     networks:
       - pcs
-  redis:
-    image: artifactory.algol60.net/docker.io/library/redis:5.0-alpine3.12
-    hostname: hms-redfish-redis
-    ports:
-      - "6379:6379"
-    networks:
-      - pcs
   hmsds-postgres:
     hostname: hmsds-postgres
     image: artifactory.algol60.net/docker.io/library/postgres:11-alpine
@@ -158,40 +151,5 @@ services:
       - ./configs/token:/configs/token
     networks:
       - pcs
-  redfish-simulator:
-    image: artifactory.algol60.net/csm-docker/stable/hms-redfish-translation-service:1.13.3
-    environment:
-      - SCHEMA_VERSION=2019.1
-      - LOG_LEVEL=TRACE
-      - PRIVILEGE_REGISTRY_VERSION=1.0.4
-      - SCRIPT_DIR_PREFIX=/tmp/redfish
-      - VAULT_TOKEN=hms
-      - REDIS_HOSTNAME=redis
-      - REDIS_PORT=6379
-      - VAULT_ADDR=http://vault:8200
-      - CRAY_VAULT_JWT_FILE=configs/token
-      - CRAY_VAULT_ROLE_FILE=configs/namespace
-      - CRAY_VAULT_AUTH_PATH=auth/token/create
-      - HTTPS_CERT=configs/rts.crt
-      - HTTPS_KEY=configs/rts.key
-      - BACKEND_HELPER=RFSimulator
-      - PERIODIC_SLEEP=120
-      - COLLECTOR_URL=http://cray-hms-hmcollector
-      - HSM_URL=http://cray-smd:27779
-      - HMS_VAULT_KEYPATH=hms-creds
-      - RF_USERNAME=root
-      - RF_PASSWORD=testpassword
-      - RF_SIMULATOR_XNAMES=x0c0s1b0,x0c0s2b0
-      - LOGLEVEL=4
-    ports:
-      - "8082:8082"
-      - "8083:8083"
-    depends_on:
-      - redis
-      - vault
-      - cray-smd
-    networks:
-      pcs:
-        aliases:
-          - x0c0s1b0
-          - x0c0s2b0
+
+# TODO replace simulated BMC with RIE

--- a/docker-compose.test.ct.yaml
+++ b/docker-compose.test.ct.yaml
@@ -178,10 +178,10 @@ services:
     networks:
       - pcs
   redfish-simulator:
-    image: artifactory.algol60.net/csm-docker/stable/hms-redfish-translation-service:1.13.3
+    image: artifactory.algol60.net/csm-docker/stable/hms-redfish-translation-service:1.20.0
     environment:
       - SCHEMA_VERSION=2019.1
-      - LOG_LEVEL=TRACE
+      - LOG_LEVEL=INFO
       - PRIVILEGE_REGISTRY_VERSION=1.0.4
       - SCRIPT_DIR_PREFIX=/tmp/redfish
       - VAULT_TOKEN=hms
@@ -191,8 +191,8 @@ services:
       - CRAY_VAULT_JWT_FILE=configs/token
       - CRAY_VAULT_ROLE_FILE=configs/namespace
       - CRAY_VAULT_AUTH_PATH=auth/token/create
-      - HTTPS_CERT=configs/rts.crt
-      - HTTPS_KEY=configs/rts.key
+      - HTTPS_CERT=/ephemeral_cert/rts.crt
+      - HTTPS_KEY=/ephemeral_cert/rts.key
       - BACKEND_HELPER=RFSimulator
       - PERIODIC_SLEEP=120
       - COLLECTOR_URL=http://cray-hms-hmcollector
@@ -205,6 +205,8 @@ services:
       - redis
       - vault
       - cray-smd
+    volumes:
+      - ./ephemeral_cert:/ephemeral_cert
     networks:
       pcs:
         aliases:

--- a/docker-compose.test.integration.yaml
+++ b/docker-compose.test.integration.yaml
@@ -73,11 +73,6 @@ services:
       - vault
     networks:
       - pcs
-  redis:
-    image: artifactory.algol60.net/docker.io/library/redis:5.0-alpine3.12
-    hostname: hms-redfish-redis
-    networks:
-      - pcs
   hmsds-postgres:
     hostname: hmsds-postgres
     image: artifactory.algol60.net/docker.io/library/postgres:11-alpine
@@ -158,36 +153,5 @@ services:
       - ./configs/token:/configs/token
     networks:
       - pcs
-  redfish-simulator:
-    image: artifactory.algol60.net/csm-docker/stable/hms-redfish-translation-service:1.13.3
-    environment:
-      - SCHEMA_VERSION=2019.1
-      - LOG_LEVEL=TRACE
-      - PRIVILEGE_REGISTRY_VERSION=1.0.4
-      - SCRIPT_DIR_PREFIX=/tmp/redfish
-      - VAULT_TOKEN=hms
-      - REDIS_HOSTNAME=redis
-      - REDIS_PORT=6379
-      - VAULT_ADDR=http://vault:8200
-      - CRAY_VAULT_JWT_FILE=configs/token
-      - CRAY_VAULT_ROLE_FILE=configs/namespace
-      - CRAY_VAULT_AUTH_PATH=auth/token/create
-      - HTTPS_CERT=configs/rts.crt
-      - HTTPS_KEY=configs/rts.key
-      - BACKEND_HELPER=RFSimulator
-      - PERIODIC_SLEEP=120
-      - COLLECTOR_URL=http://cray-hms-hmcollector
-      - HSM_URL=http://cray-smd:27779
-      - HMS_VAULT_KEYPATH=hms-creds
-      - RF_USERNAME=root
-      - RF_PASSWORD=testpassword
-      - RF_SIMULATOR_XNAMES=x0c0s1b0,x0c0s2b0
-    depends_on:
-      - redis
-      - vault
-      - cray-smd
-    networks:
-      pcs:
-        aliases:
-          - x0c0s1b0
-          - x0c0s2b0
+
+# TODO replace simulated BMC with RIE

--- a/docker-compose.test.unit.yaml
+++ b/docker-compose.test.unit.yaml
@@ -147,10 +147,10 @@ services:
     networks:
       - pcs
   redfish-simulator:
-    image: artifactory.algol60.net/csm-docker/stable/hms-redfish-translation-service:1.13.3
+    image: artifactory.algol60.net/csm-docker/stable/hms-redfish-translation-service:1.20.0
     environment:
       - SCHEMA_VERSION=2019.1
-      - LOG_LEVEL=TRACE
+      - LOG_LEVEL=INFO
       - PRIVILEGE_REGISTRY_VERSION=1.0.4
       - SCRIPT_DIR_PREFIX=/tmp/redfish
       - VAULT_TOKEN=hms
@@ -160,8 +160,8 @@ services:
       - CRAY_VAULT_JWT_FILE=configs/token
       - CRAY_VAULT_ROLE_FILE=configs/namespace
       - CRAY_VAULT_AUTH_PATH=auth/token/create
-      - HTTPS_CERT=configs/rts.crt
-      - HTTPS_KEY=configs/rts.key
+      - HTTPS_CERT=/ephemeral_cert/rts.crt
+      - HTTPS_KEY=/ephemeral_cert/rts.key
       - BACKEND_HELPER=RFSimulator
       - PERIODIC_SLEEP=120
       - COLLECTOR_URL=http://cray-hms-hmcollector
@@ -174,6 +174,8 @@ services:
       - redis
       - vault
       - cray-smd
+    volumes:
+      - ./ephemeral_cert:/ephemeral_cert
     networks:
       pcs:
         aliases:

--- a/runCT.sh
+++ b/runCT.sh
@@ -70,11 +70,15 @@ function cleanup() {
 mkdir -p $ephCertDir
 openssl req -newkey rsa:4096 \
     -x509 -sha256 \
-    -days 3650 \
+    -days 1 \
     -nodes \
     -subj "/C=US/ST=Minnesota/L=Bloomington/O=HPE/OU=Engineering/CN=hpe.com" \
-    -out $ephCertDir/tls.crt \
-    -keyout $ephCertDir/tls.key
+    -out $ephCertDir/rts.crt \
+    -keyout $ephCertDir/rts.key
+
+# When running in github actions the rts.key gets created with u+rw permissions.
+# This prevents RTS which runs as nobody to read the key as it doesn't have permission.
+chmod o+r $ephCertDir/rts.crt $ephCertDir/rts.key
 
 # Get the base containers running
 echo "Starting containers..."

--- a/runIntegration.sh
+++ b/runIntegration.sh
@@ -29,14 +29,12 @@ set -x
 # Configure docker compose
 export COMPOSE_PROJECT_NAME=$RANDOM
 export COMPOSE_FILE=docker-compose.test.integration.yaml
-ephCertDir=ephemeral_cert
 
 echo "COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME}"
 echo "COMPOSE_FILE: $COMPOSE_FILE"
 
 
 function cleanup() {
-  rm -rf $ephCertDir
   docker-compose down
   if ! [[ $? -eq 0 ]]; then
     echo "Failed to decompose environment!"
@@ -44,17 +42,6 @@ function cleanup() {
   fi
   exit $1
 }
-
-# Create "ephemeral" TLS .crt and .key files
-
-mkdir -p $ephCertDir
-openssl req -newkey rsa:4096 \
-    -x509 -sha256 \
-    -days 3650 \
-    -nodes \
-    -subj "/C=US/ST=Minnesota/L=Bloomington/O=HPE/OU=Engineering/CN=hpe.com" \
-    -out $ephCertDir/tls.crt \
-    -keyout $ephCertDir/tls.key
 
 echo "Starting containers..."
 docker-compose build

--- a/runUnitTest.sh
+++ b/runUnitTest.sh
@@ -51,16 +51,20 @@ function cleanup() {
 mkdir -p $ephCertDir
 openssl req -newkey rsa:4096 \
     -x509 -sha256 \
-    -days 3650 \
+    -days 1 \
     -nodes \
     -subj "/C=US/ST=Minnesota/L=Bloomington/O=HPE/OU=Engineering/CN=hpe.com" \
     -out $ephCertDir/rts.crt \
     -keyout $ephCertDir/rts.key
 
+# When running in github actions the rts.key gets created with u+rw permissions.
+# This prevents RTS which runs as nobody to read the key as it doesn't have permission.
+chmod o+r $ephCertDir/rts.crt $ephCertDir/rts.key
 
 echo "Starting containers..."
 docker-compose build
 docker-compose up  -d dummy #we use dummy to make sure all our dependencies are up
+docker-compose ps # To improve debuggability display the current state of the conainers.
 docker-compose up --exit-code-from unit-tests unit-tests
 
 test_result=$?

--- a/testing/ct/Dockerfile
+++ b/testing/ct/Dockerfile
@@ -1,4 +1,4 @@
-FROM artifactory.algol60.net/csm-docker/stable/hms-test:3.0.0
+FROM artifactory.algol60.net/csm-docker/stable/hms-test:3.2.0
 
 COPY smoke/ /src/app
 COPY functional/ /src/app


### PR DESCRIPTION
### Summary and Scope
- Updated RTS to a newer image that does not have hardcoded HTTPs certificate in it. 
- Fixed tests to properly utilize ephemeral cert
- Removed  ephemeral cert generation from run integration since the integration tests do not currently depend on RTS. When the integration tests get written for PCS, RIE will most likely be used instead of RTS.
- Removed RTS where it not needed (to be replaced with RIE at a later date). The following docker-compose files had RTS removed:
  - docker-compose.developer.environment.yaml
  - docker-compose.developer.full.yaml
  - docker-compose.test.integration.yaml
- Update the CT tests to use the latest hms-test image.



### Issues and Related PRs

* Partially resolves CASMHMS-5622.

### Risks and Mitigations
Low risk.